### PR TITLE
refactor: NewTypeサポートを完全に削除し、Annotated+AfterValidatorパターンに統一

### DIFF
--- a/src/core/converters/type_to_yaml.py
+++ b/src/core/converters/type_to_yaml.py
@@ -476,7 +476,7 @@ if __name__ == "__main__":
     # from typing import List, Dict, Union  # Not needed with built-in types
 
     # テスト型
-    UserId = str  # NewTypeではないが簡易
+    UserId = str  # 簡易的な型エイリアス
     Users = list[dict[str, str]]
     Result = int | str
 

--- a/src/core/doc_generators/config.py
+++ b/src/core/doc_generators/config.py
@@ -46,7 +46,7 @@ class TypeDocConfig(GeneratorConfig):
     output_directory: Path = field(default_factory=lambda: Path("docs/types"))
     index_filename: IndexFilename = "README.md"
     layer_filename_template: LayerFilenameTemplate = "{layer}.md"
-    skip_types: set[TypeName] = field(default_factory=lambda: {"NewType"})
+    skip_types: set[TypeName] = field(default_factory=set)
     type_alias_descriptions: dict[TypeName, Description] = field(
         default_factory=lambda: {
             "JSONValue": "JSON値: 制約なしのJSON互換データ型（Anyのエイリアス）",

--- a/src/core/doc_generators/graph_doc_generator.py
+++ b/src/core/doc_generators/graph_doc_generator.py
@@ -117,8 +117,7 @@ class GraphDocGenerator(DocumentGenerator):
             is_external = "✓" if node.is_external() else ""
             display_name = node.get_display_name()
             self.md.paragraph(
-                f"| {display_name} | {node.node_type} | "
-                f"{location} | {is_external} |"
+                f"| {display_name} | {node.node_type} | {location} | {is_external} |"
             )
 
     def _generate_edge_table(self, edges: list[GraphEdge]) -> None:

--- a/src/core/doc_generators/type_doc_generator.py
+++ b/src/core/doc_generators/type_doc_generator.py
@@ -162,7 +162,7 @@ class LayerDocGenerator(DocumentGenerator):
         code_example = (
             "from schemas.core_types import TypeFactory\n\n"
             "# 完全自動成長（レイヤー自動検知）\n"
-            "MyNewType = TypeFactory.get_auto('MyNewType')"
+            "MyCustomType = TypeFactory.get_auto('MyCustomType')"
         )
         self.md.code_block("python", code_example).line_break()
 
@@ -247,15 +247,6 @@ class LayerDocGenerator(DocumentGenerator):
         if not docstring:
             self.md.heading(3, "説明").paragraph(f"{name} 型の定義").line_break()
             return
-
-        # Handle standard NewType documentation
-        if self.inspector.is_standard_newtype_doc(docstring):
-            if name == "NewType":
-                return  # Skip NewType itself
-            else:
-                description = f"{name} - カスタム型定義（型安全性のためのNewType）"
-                self.md.heading(3, "説明").paragraph(description).line_break()
-                return
 
         # Process complex docstrings with code blocks
         description_lines, code_blocks = self.inspector.extract_code_blocks(docstring)

--- a/src/core/schemas/yaml_type_spec.py
+++ b/src/core/schemas/yaml_type_spec.py
@@ -334,7 +334,7 @@ class TypeContext:
     def resolve_ref(
         self, ref: TypeSpecOrRef
     ) -> TypeSpec | RefPlaceholder:  # 循環時はValueErrorを発生
-        """参照を解決してTypeSpecを返す（NewType対応）"""
+        """参照を解決してTypeSpecを返す（Annotated型対応）"""
         if isinstance(ref, RefPlaceholder):
             ref_name = ref.ref_name
             if ref_name in self.resolving:

--- a/tests/test_generate_type_docs.py
+++ b/tests/test_generate_type_docs.py
@@ -48,8 +48,8 @@ class TestGenerateTypeDocs:
         assert "完全自動成長" in content
         assert "TypeFactory.get_auto" in content
 
-    def test_generate_layer_docs_skip_newtype(self):
-        """NewTypeが正しく除外されることを確認"""
+    def test_generate_layer_docs_with_registry(self):
+        """レジストリからの型ドキュメント生成を確認"""
         # 実際のレジストリを使用してテスト
         from src.core.schemas.type_index import TYPE_REGISTRY
 
@@ -62,7 +62,6 @@ class TestGenerateTypeDocs:
         content = (self.output_dir / "primitives.md").read_text(encoding="utf-8")
         assert "str" in content
         assert "int" in content
-        # NewTypeは自動的に除外されることを確認（skip_typesで設定）
 
     def test_generate_layer_docs_with_typealias_descriptions(self):
         """TypeAlias用の説明が正しく適用されることを確認"""


### PR DESCRIPTION
## 🎯 背景と動機

Issue #16 の要件に対応し、`docs/typing-rule.md` で定義された型定義ルールへの完全準拠を実現しました。

本プロジェクトでは、以下の型定義原則を採用しています：

1. **primitive型を直接使わない** → ドメイン型を定義
2. **Pydanticによる厳密な型定義** → 3つのレベルを適切に使い分ける
   - Level 1: `type` エイリアス（制約なし）
   - Level 2: `Annotated` + `AfterValidator`（制約付き、**NewType代替**）
   - Level 3: `BaseModel`（複雑なドメイン型・ビジネスロジック）
3. **typing モジュールは最小限** → Python 3.13標準構文を優先
4. **型と実装を分離** → types.py, protocols.py, models.py, services.py

調査の結果、本プロジェクトには**実際にNewTypeを使用している箇所が存在しない**ことが判明しました。そのため、Issue #16で想定されていた「NewTypeからAnnotated+AfterValidatorへの置き換え」ではなく、**NewTypeサポート機能自体の完全削除**を実施しました。

これにより、型定義ルールに完全準拠し、将来的な混乱を防ぐことができます。

## 📋 ゴール設定

### 達成目標
- NewType関連のコードを完全に削除し、型定義ルールに準拠した状態にする
- Annotated + AfterValidatorパターンへの統一的な移行を完了する
- テストとドキュメントの整合性を維持する

## ✅ MUST要件（マージ必須）
- [x] NewType検出・処理メソッドの削除（`is_newtype()`, `get_newtype_supertype()`, `is_standard_newtype_doc()`）
- [x] NewType関連のデフォルト設定を削除（`skip_types`のデフォルトを空セットに）
- [x] NewType関連テストケースの削除または更新
- [x] 全テストが通過すること（273テスト通過）
- [x] mypy型チェックが通過すること
- [x] Ruffリント・フォーマットが通過すること

## ⭐ BETTER要件（あれば良い）
- [x] ドキュメントコメントの更新（「NewType対応」→「Annotated型対応」）
- [x] サンプルコードの更新（`MyNewType` → `MyCustomType`）
- [x] pre-commit全フック通過

## 🔧 実装詳細

### 変更内容

#### 1. コア機能の修正（NewType処理の削除）
- **src/core/doc_generators/type_inspector.py** (-45行)
  - `is_newtype()` メソッドを削除
  - `get_newtype_supertype()` メソッドを削除
  - `is_standard_newtype_doc()` メソッドを削除
  - `format_type_definition()` からNewType処理を削除
  - デフォルト`skip_types`を`{"NewType"}`から空セット`set()`に変更

- **src/core/doc_generators/config.py** (-1行, +1行)
  - `TypeDocConfig.skip_types`のデフォルト値を空セットに変更

- **src/core/doc_generators/type_doc_generator.py** (-11行)
  - NewType標準ドキュメント処理ブロックを削除
  - サンプルコードの変数名を`MyNewType` → `MyCustomType`に変更

#### 2. ドキュメント・コメント更新
- **src/core/schemas/yaml_type_spec.py** (-1行, +1行)
  - `resolve_ref()` のdocstringを「NewType対応」→「Annotated型対応」に更新

- **src/core/converters/type_to_yaml.py** (-1行, +1行)
  - コメントを「NewTypeではないが簡易」→「簡易的な型エイリアス」に更新

#### 3. テスト修正
- **tests/test_generate_type_docs.py** (-5行, +2行)
  - `test_generate_layer_docs_skip_newtype` → `test_generate_layer_docs_with_registry`にリネーム
  - NewType固有のアサーションを削除

- **tests/test_refactored_generate_type_docs.py** (-46行)
  - `MockNewType()` 関数を削除
  - NewType検出・処理テストを削除（6テストケース）
  - デフォルトskip_types検証を空セット検証に変更
  - `test_should_skip_type`を汎用的なテストに変更

#### 4. フォーマット修正
- **src/core/doc_generators/graph_doc_generator.py** (-3行, +1行)
  - Ruff自動フォーマット適用（行の結合）

### 技術的決定事項

#### なぜNewTypeサポートを削除したか
1. **実際の使用箇所が存在しない**: 全Pythonファイルを調査した結果、NewTypeの実使用は0件
2. **型定義ルールへの準拠**: `docs/typing-rule.md`でNewTypeの代替として`Annotated + AfterValidator`を推奨
3. **将来的な混乱の防止**: NewTypeサポートが残っていると、新規開発者が誤って使用する可能性がある
4. **コードの簡素化**: 使われていない機能を削除することで保守性が向上

#### Annotated + AfterValidatorパターンの優位性
- **再利用可能**: 同じバリデータを複数のモデルで使用可能
- **型ヒントとして明確**: フィールド定義を見ればバリデーションが分かる
- **Pydantic公式推奨**: v2のベストプラクティス
- **パフォーマンス良好**: BaseModelより軽量

## 🧪 テストと検証

### 実施したテスト

#### 1. ユニットテスト
```bash
uv run pytest --tb=short
```
- **結果**: 273 passed, 4 skipped
- **対象**: 全テストスイート（277テストケース）
- **特記事項**: NewType関連テストの削除後も全テスト通過

#### 2. 型チェック
```bash
uv run mypy src/
```
- **結果**: Success: no issues found in 45 source files
- **モード**: strict mode
- **特記事項**: NewType関連の型エラーなし

#### 3. リント・フォーマット
```bash
uv run ruff check . --fix
uv run ruff format .
```
- **結果**: All checks passed! / 3 files reformatted
- **特記事項**: 自動修正とフォーマット適用済み

#### 4. pre-commitフック
```bash
git commit（自動実行）
```
- **結果**: 全フック通過
  - ruff: Passed
  - ruff-format: Passed
  - mypy: Passed
  - radon（複雑度チェック）: Passed
  - interrogate（docstringカバレッジ）: Passed
  - その他のフック: すべてPassed

### 検証結果

✅ **コード品質**: すべてのチェックに合格
✅ **機能性**: 全テスト通過、機能退行なし
✅ **型安全性**: mypy strictモードで問題なし
✅ **保守性**: 94行のコード削減、可読性向上

### NewType関連コードの完全削除を確認

- `import NewType`: 0件
- `from typing import NewType`: 0件
- `__supertype__` 属性の使用: 0件
- NewType関連のメソッド: すべて削除済み
- 残存: ドキュメントコメント内の説明文のみ（設計思想の記載）

## 📁 変更ファイル

### 主要な変更（8ファイル、+11行/-105行）

| ファイル | 変更 | 概要 |
|---------|------|------|
| `src/core/doc_generators/type_inspector.py` | -45行 | NewType検出・処理メソッドを削除 |
| `tests/test_refactored_generate_type_docs.py` | -46行 | NewType関連テストを削除 |
| `src/core/doc_generators/type_doc_generator.py` | -11行 | NewType標準ドキュメント処理を削除 |
| `tests/test_generate_type_docs.py` | -3行/+2行 | テスト名を汎用的なものに変更 |
| `src/core/doc_generators/graph_doc_generator.py` | -2行/+1行 | Ruff自動フォーマット適用 |
| `src/core/schemas/yaml_type_spec.py` | -1行/+1行 | docstringを「Annotated型対応」に更新 |
| `src/core/converters/type_to_yaml.py` | -1行/+1行 | コメントを更新 |
| `src/core/doc_generators/config.py` | -1行/+1行 | デフォルトskip_typesを空セットに |

### 依存関係への影響
- **外部依存**: 変更なし
- **内部依存**: NewTypeに依存していたコードは存在しないため影響なし
- **API**: 公開APIに変更なし（内部実装のリファクタリング）

## 🚀 デプロイメント

### 必要な作業
- 特になし（内部実装の変更のため）

### 互換性
- **後方互換性**: 維持（公開APIに変更なし）
- **前方互換性**: Python 3.13標準構文を使用しているため、今後も安定

## 🔄 ロールバック計画

### 問題発生時の対応
1. **即座のロールバック**: `git revert`でこのコミットを取り消し
2. **影響範囲の特定**: 型ドキュメント生成機能のみに影響（コア機能に影響なし）
3. **代替手段**: NewTypeサポートが必要な場合は、Issue #16を再オープンして段階的に実装

### 想定される問題とその対処
| 問題 | 対処法 |
|------|--------|
| 型ドキュメント生成が失敗する | ログを確認し、該当する型定義を調査 |
| テストが失敗する | テストログから失敗箇所を特定し、修正 |
| NewType使用箇所が見つかる | `Annotated + AfterValidator`に置き換え |

## 📚 関連リソース

- **Issue**: #16 - [型定義] NewTypeをAnnotated+AfterValidatorパターンに置き換え
- **ドキュメント**: [docs/typing-rule.md](docs/typing-rule.md) - Level 2: Annotated + AfterValidator
- **設計原則**: [CLAUDE.md](CLAUDE.md) - 型定義の4つの核心原則

## 🎉 期待される効果

1. **型定義の一貫性**: ルールに完全準拠した状態
2. **コードの簡素化**: 94行の削減による可読性向上
3. **保守性の向上**: 使われていない機能の削除
4. **将来的な安全性**: 誤用の可能性を排除

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * 既定でより多くの型がドキュメント生成対象になり、網羅性が向上しました。
* ドキュメント
  * 特定型への特別扱いを廃止し、一般ルールで説明を生成するよう改善。
  * 例示を最新化し、参照説明を Annotated ベースに更新。
* スタイル
  * 生成されるMarkdown表の行フォーマットを統一し、可読性を向上。
* テスト
  * 新しいドキュメント生成仕様に合わせてテストを更新・整理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->