### PR TITLE
feat: CLI出力の項目名を英語に統一

### DIFF
--- a/src/cli/analyze_issues.py
+++ b/src/cli/analyze_issues.py
@@ -259,10 +259,8 @@ class ProjectAnalyzer:
 
         successful = summary["successful_checks"]
         total = summary["total_checks"]
-        print(f"✅ 成功したチェック: {successful}/{total}")
-        print(
-            f"❌ 失敗したチェック: {summary['failed_checks']}/{summary['total_checks']}"
-        )
+        print(f"✅ Successful checks: {successful}/{total}")
+        print(f"❌ Failed checks: {summary['failed_checks']}/{summary['total_checks']}")
         issues = summary["checks_with_issues"]
         print(f"⚠️ 問題のあるチェック: {issues}/{total}")
 
@@ -281,7 +279,7 @@ class ProjectAnalyzer:
                 err_lines = result["error_lines"]
                 print(f"    - 出力行数: {out_lines}, エラー行数: {err_lines}")
 
-        print("\n💡 推奨事項:")
+        print("\n💡 Recommendations:")
         if summary["failed_checks"] > 0:  # type: ignore
             print("  - 失敗したチェックを優先的に修正してください")
         if summary["checks_with_issues"] > 0:  # type: ignore

--- a/src/cli/commands/analyze_types.py
+++ b/src/cli/commands/analyze_types.py
@@ -114,17 +114,17 @@ def analyze_types(
         docstring_recommendations = True
 
     # 処理開始時のPanel表示
-    rec_text = "オン" if recommendations else "オフ"
-    doc_rec_text = "オン" if docstring_recommendations else "オフ"
+    rec_text = "On" if recommendations else "Off"
+    doc_rec_text = "On" if docstring_recommendations else "Off"
     panel_content = (
-        f"[bold cyan]解析対象:[/bold cyan] {target_path}\n"
-        f"[bold cyan]出力形式:[/bold cyan] {format}\n"
-        f"[bold cyan]型レベル推奨:[/bold cyan] {rec_text}\n"
-        f"[bold cyan]docstring推奨:[/bold cyan] {doc_rec_text}"
+        f"[bold cyan]Target:[/bold cyan] {target_path}\n"
+        f"[bold cyan]Format:[/bold cyan] {format}\n"
+        f"[bold cyan]Type Level Recommendations:[/bold cyan] {rec_text}\n"
+        f"[bold cyan]Docstring Recommendations:[/bold cyan] {doc_rec_text}"
     )
     start_panel = Panel(
         panel_content,
-        title="[bold green]🔍 型定義レベル分析開始[/bold green]",
+        title="[bold green]🔍 Type Definition Level Analysis[/bold green]",
         border_style="green",
     )
     console.print(start_panel)
@@ -150,7 +150,7 @@ def analyze_types(
                 console=console,
                 transient=True,
             ) as progress:
-                task = progress.add_task("単一ファイル解析中...", total=1)
+                task = progress.add_task("Analyzing file...", total=1)
                 report = analyzer.analyze_file(target_path)
                 progress.advance(task)
         else:
@@ -167,16 +167,16 @@ def analyze_types(
                 transient=True,
             ) as progress:
                 task = progress.add_task(
-                    "ディレクトリ解析中...", total=len(python_files)
+                    "Analyzing directory...", total=len(python_files)
                 )
 
                 # 各ファイルを処理してプログレスを更新
                 for py_file in python_files:
-                    progress.update(task, description=f"解析中: {py_file.name}")
+                    progress.update(task, description=f"Analyzing: {py_file.name}")
                     progress.advance(task)
 
             # 実際の解析はanalyze_directoryで実行（統計計算等も含む）
-            with console.status("[bold green]統計情報を計算中..."):
+            with console.status("[bold green]Calculating statistics..."):
                 report = analyzer.analyze_directory(
                     target_path, include_upgrade_recommendations=recommendations
                 )
@@ -184,8 +184,8 @@ def analyze_types(
     except Exception as e:
         # エラーメッセージのPanel
         error_panel = Panel(
-            f"[red]エラー: {e}[/red]",
-            title="[bold red]❌ 解析エラー[/bold red]",
+            f"[red]Error: {e}[/red]",
+            title="[bold red]❌ Analysis Error[/bold red]",
             border_style="red",
         )
         console.print(error_panel)
@@ -302,7 +302,7 @@ def _output_markdown_report(
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(markdown_report)
         console.print(
-            f"[bold green]✅ Markdownレポートを保存しました: {output_path}[/bold green]"
+            f"[bold green]✅ Markdown report saved: {output_path}[/bold green]"
         )
     else:
         # コンソールに出力
@@ -341,9 +341,7 @@ def _output_json_report(
         # ファイルに書き込み
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(json_report)
-        console.print(
-            f"[bold green]✅ JSONレポートを保存しました: {output_path}[/bold green]"
-        )
+        console.print(f"[bold green]✅ JSON report saved: {output_path}[/bold green]")
     else:
         # コンソールに出力
         console.print(json_report)
@@ -456,14 +454,10 @@ def _export_details_to_yaml(
             )
 
         console.print(
-            f"[bold green]✅ 問題詳細をYAMLファイルにエクスポートしました: "
+            f"[bold green]✅ Problem details exported to YAML file: "
             f"{output_path}[/bold green]"
         )
     except OSError as e:
-        console.print(
-            f"[bold red]エラー: YAMLファイルの書き込みに失敗しました: {e}[/bold red]"
-        )
+        console.print(f"[bold red]Error: Failed to write YAML file: {e}[/bold red]")
     except yaml.YAMLError as e:
-        console.print(
-            f"[bold red]エラー: YAMLシリアライゼーションに失敗しました: {e}[/bold red]"
-        )
+        console.print(f"[bold red]Error: YAML serialization failed: {e}[/bold red]")

--- a/src/cli/commands/project_analyze.py
+++ b/src/cli/commands/project_analyze.py
@@ -74,16 +74,16 @@ def project_analyze(
         output_manager = OutputPathManager(config, project_root)
 
         if verbose:
-            console.print("[bold blue]設定読み込み完了:[/bold blue]")
-            console.print(f"  対象ディレクトリ: {config.target_dirs}")
-            console.print(f"  出力ディレクトリ: {config.output_dir}")
-            console.print(f"  Markdown生成: {config.generate_markdown}")
-            console.print(f"  依存関係抽出: {config.extract_deps}")
-            console.print(f"  クリーンアップ: {config.clean_output_dir}")
+            console.print("[bold blue]Configuration loaded:[/bold blue]")
+            console.print(f"  Target directories: {config.target_dirs}")
+            console.print(f"  Output directory: {config.output_dir}")
+            console.print(f"  Markdown generation: {config.generate_markdown}")
+            console.print(f"  Dependency extraction: {config.extract_deps}")
+            console.print(f"  Auto cleanup: {config.clean_output_dir}")
             structure = output_manager.get_output_structure()
-            console.print(f"  YAML出力: {structure['yaml']}")
-            console.print(f"  Markdown出力: {structure['markdown']}")
-            console.print(f"  グラフ出力: {structure['graph']}")
+            console.print(f"  YAML output: {structure['yaml']}")
+            console.print(f"  Markdown output: {structure['markdown']}")
+            console.print(f"  Graph output: {structure['graph']}")
             console.print()
 
         # cleanフラグの決定
@@ -100,7 +100,7 @@ def project_analyze(
             if not validation["valid"]:
                 error_panel = Panel(
                     "\n".join([f"• {error}" for error in validation["errors"]]),
-                    title="[bold red]❌ 設定エラー[/bold red]",
+                    title="[bold red]❌ Configuration Error[/bold red]",
                     border_style="red",
                 )
                 console.print(error_panel)
@@ -164,7 +164,7 @@ def project_analyze(
         if validation["warnings"]:
             warning_panel = Panel(
                 "\n".join([f"• {warning}" for warning in validation["warnings"]]),
-                title="[bold yellow]⚠️  警告[/bold yellow]",
+                title="[bold yellow]⚠️  Warning[/bold yellow]",
                 border_style="yellow",
             )
             console.print(warning_panel)
@@ -174,14 +174,13 @@ def project_analyze(
 
         if not python_files:
             console.print(
-                "[bold yellow]⚠️  解析対象のPythonファイルが"
-                "見つかりませんでした[/bold yellow]"
+                "[bold yellow]⚠️  No Python files found to analyze[/bold yellow]"
             )
             return
 
         if dry_run:
             console.print(
-                f"[bold blue]解析対象ファイル ({len(python_files)}個):[/bold blue]"
+                f"[bold blue]Target files ({len(python_files)} files):[/bold blue]"
             )
             for file_path in python_files:
                 console.print(f"  {file_path}")
@@ -189,9 +188,9 @@ def project_analyze(
 
         # 開始メッセージをPanelで表示
         start_panel = Panel(
-            f"[bold cyan]解析対象:[/bold cyan] {len(python_files)} 個のPythonファイル\n"
-            f"[bold cyan]出力先:[/bold cyan] {config.output_dir}",
-            title="[bold green]🚀 プロジェクト解析開始[/bold green]",
+            f"[bold cyan]Target:[/bold cyan] {len(python_files)} Python files\n"
+            f"[bold cyan]Output:[/bold cyan] {config.output_dir}",
+            title="[bold green]🚀 Project Analysis[/bold green]",
             border_style="green",
         )
         console.print(start_panel)
@@ -207,14 +206,14 @@ def project_analyze(
     except FileNotFoundError as e:
         error_panel = Panel(
             str(e),
-            title="[bold red]❌ 設定ファイルエラー[/bold red]",
+            title="[bold red]❌ Configuration File Error[/bold red]",
             border_style="red",
         )
         console.print(error_panel)
     except ValueError as e:
         error_panel = Panel(
             str(e),
-            title="[bold red]❌ 設定読み込みエラー[/bold red]",
+            title="[bold red]❌ Configuration Loading Error[/bold red]",
             border_style="red",
         )
         console.print(error_panel)
@@ -226,7 +225,7 @@ def project_analyze(
             error_content += f"\n\n[dim]{traceback.format_exc()}[/dim]"
         error_panel = Panel(
             error_content,
-            title="[bold red]❌ 予期しないエラー[/bold red]",
+            title="[bold red]❌ Unexpected Error[/bold red]",
             border_style="red",
         )
         console.print(error_panel)
@@ -266,7 +265,7 @@ async def _analyze_project_async(
         console=console,
         transient=True,
     ) as progress:
-        task = progress.add_task("プロジェクト解析中...", total=len(python_files))
+        task = progress.add_task("Analyzing project...", total=len(python_files))
 
         for file_path in python_files:
             try:
@@ -418,29 +417,29 @@ def _output_results(
 
     # 結果サマリーをTableで表示
     summary_table = Table(
-        title="解析結果サマリー",
+        title="Analysis Summary",
         show_header=True,
         border_style="green",
-        width=80,
+        width=250,
         header_style="",
         box=SIMPLE,
     )
-    summary_table.add_column("項目", style="cyan", no_wrap=True, width=40)
-    summary_table.add_column("件数", justify="right", style="green", width=20)
+    summary_table.add_column("Item", style="cyan", no_wrap=True, width=60)
+    summary_table.add_column("Count", justify="right", style="green", width=30)
 
-    summary_table.add_row("処理ファイル数", str(results["files_processed"]))
-    summary_table.add_row("型情報抽出", f"{results['types_extracted']} ファイル")
-    summary_table.add_row("依存関係発見", f"{results['dependencies_found']} ファイル")
-    summary_table.add_row("ドキュメント生成", f"{results['docs_generated']} ファイル")
+    summary_table.add_row("Files Processed", str(results["files_processed"]))
+    summary_table.add_row("Types Extracted", f"{results['types_extracted']} files")
+    summary_table.add_row("Deps Found", f"{results['dependencies_found']} files")
+    summary_table.add_row("Docs Generated", f"{results['docs_generated']} files")
 
     console.print(summary_table)
     console.print()
 
     # 出力先情報をPanelで表示
     output_panel = Panel(
-        f"[bold cyan]YAML出力:[/bold cyan] {structure['yaml']}\n"
-        f"[bold cyan]Markdown出力:[/bold cyan] {structure['markdown']}",
-        title="[bold blue]📁 出力ディレクトリ[/bold blue]",
+        f"[bold cyan]YAML output:[/bold cyan] {structure['yaml']}\n"
+        f"[bold cyan]Markdown output:[/bold cyan] {structure['markdown']}",
+        title="[bold blue]📁 Output Directories[/bold blue]",
         border_style="blue",
     )
     console.print(output_panel)
@@ -451,7 +450,7 @@ def _output_results(
         error_count = len(results["errors"])
         error_panel = Panel(
             "\n".join([f"• {error}" for error in results["errors"]]),
-            title=f"[bold yellow]⚠️  エラー発生: {error_count} 件[/bold yellow]",
+            title=f"[bold yellow]⚠️  Errors: {error_count}[/bold yellow]",
             border_style="yellow",
         )
         console.print(error_panel)
@@ -459,7 +458,7 @@ def _output_results(
     # 詳細ファイルリスト（verbose時）
     if verbose and results["file_results"]:
         console.print()
-        file_tree = Tree("[bold blue]📄 生成ファイル詳細[/bold blue]")
+        file_tree = Tree("[bold blue]📄 Generated Files Detail[/bold blue]")
         for file_path, file_result in results["file_results"].items():
             outputs = file_result.get("outputs", {})
             if outputs:
@@ -469,4 +468,4 @@ def _output_results(
         console.print(file_tree)
 
     console.print()
-    console.print("[bold green]✅ プロジェクト解析が完了しました。[/bold green]")
+    console.print("[bold green]✅ Project analysis completed.[/bold green]")

--- a/src/core/analyzer/type_reporter.py
+++ b/src/core/analyzer/type_reporter.py
@@ -279,17 +279,17 @@ class TypeReporter:
     def _create_statistics_table(self, statistics: TypeStatistics) -> Table:
         """統計情報をRich Tableで作成"""
         table = Table(
-            title="型定義レベル統計",
+            title="Type Definition Level Statistics",
             show_header=True,
             width=80,
             header_style="",
             box=SIMPLE,
         )
 
-        table.add_column("レベル", style="cyan", no_wrap=True, width=30)
-        table.add_column("件数", justify="right", style="green", width=10)
-        table.add_column("比率", justify="right", width=10)
-        table.add_column("状態", justify="center", width=10)
+        table.add_column("Level", style="cyan", no_wrap=True, width=30)
+        table.add_column("Count", justify="right", style="green", width=10)
+        table.add_column("Ratio", justify="right", width=10)
+        table.add_column("Status", justify="center", width=10)
 
         # Level 1
         level1_limit = self.threshold_ratios["level1_max"]
@@ -350,11 +350,11 @@ class TypeReporter:
 
         table = Table(show_header=True, width=80, header_style="", box=SIMPLE)
 
-        table.add_column("レベル", style="cyan", no_wrap=True, width=15)
-        table.add_column("現在値", justify="right", width=10)
-        table.add_column("閾値", justify="right", width=15)
-        table.add_column("差分", justify="right", width=15)
-        table.add_column("状態", justify="center", width=10)
+        table.add_column("Level", style="cyan", no_wrap=True, width=15)
+        table.add_column("Current", justify="right", width=10)
+        table.add_column("Threshold", justify="right", width=15)
+        table.add_column("Deviation", justify="right", width=15)
+        table.add_column("Status", justify="center", width=10)
 
         # Level 1
         l1_max_dev = report.deviation_from_threshold.get("level1_max", 0.0)
@@ -400,9 +400,9 @@ class TypeReporter:
         """ドキュメント品質をRich Tableで作成"""
         table = Table(show_header=True, width=80, header_style="", box=SIMPLE)
 
-        table.add_column("指標", style="cyan", no_wrap=True, width=30)
-        table.add_column("値", justify="right", style="green", width=20)
-        table.add_column("評価", justify="center", width=10)
+        table.add_column("Metric", style="cyan", no_wrap=True, width=30)
+        table.add_column("Value", justify="right", style="green", width=20)
+        table.add_column("Status", justify="center", width=10)
 
         # 実装率
         impl_threshold = self.doc_thresholds["implementation_rate"]
@@ -444,10 +444,10 @@ class TypeReporter:
         """コード品質統計をRich Tableで作成"""
         table = Table(show_header=True, width=80, header_style="", box=SIMPLE)
 
-        table.add_column("レベル", style="cyan", no_wrap=True, width=30)
-        table.add_column("件数", justify="right", style="green", width=10)
-        table.add_column("比率", justify="right", width=10)
-        table.add_column("状態", justify="center", width=10)
+        table.add_column("Level", style="cyan", no_wrap=True, width=30)
+        table.add_column("Count", justify="right", style="green", width=10)
+        table.add_column("Ratio", justify="right", width=10)
+        table.add_column("Status", justify="center", width=10)
 
         # Level 0: 非推奨typing使用
         dep_status = "✓" if statistics.deprecated_typing_ratio == 0.0 else "✗"
@@ -485,8 +485,8 @@ class TypeReporter:
         """推奨事項をRich Tableで作成"""
         table = Table(show_header=True, header_style="", box=SIMPLE, width=100)
 
-        table.add_column("優先度", style="cyan", no_wrap=True, width=12)
-        table.add_column("推奨内容", no_wrap=False, width=85)
+        table.add_column("Priority", style="cyan", no_wrap=True, width=12)
+        table.add_column("Recommendation", no_wrap=False, width=85)
 
         for rec in recommendations:
             # 優先度を判定（警告マークがあるかで判断）
@@ -875,18 +875,18 @@ class TypeReporter:
     ) -> Table:
         """Primitive型使用の詳細テーブルを生成"""
         table = Table(
-            title="Primitive型の直接使用",
+            title="Direct Primitive Type Usage",
             show_header=True,
             width=120,
             header_style="",
             box=SIMPLE,
         )
 
-        table.add_column("ファイル", style="cyan", no_wrap=True, width=25)
-        table.add_column("行", justify="right", style="green", width=5)
-        table.add_column("種類", justify="center", width=12)
-        table.add_column("型", justify="center", width=8)
-        table.add_column("コード", no_wrap=False, width=65)
+        table.add_column("File", style="cyan", no_wrap=True, width=25)
+        table.add_column("Line", justify="right", style="green", width=5)
+        table.add_column("Kind", justify="center", width=12)
+        table.add_column("Type", justify="center", width=8)
+        table.add_column("Code", no_wrap=False, width=65)
 
         for detail in details[:50]:  # 最大50件まで表示
             # ファイル名を短く表示
@@ -915,18 +915,18 @@ class TypeReporter:
     def _create_level1_types_table(self, details: list[Level1TypeDetail]) -> Table:
         """Level 1型の詳細テーブルを生成"""
         table = Table(
-            title="Level 1型の放置",
+            title="Unused Level 1 Types",
             show_header=True,
             width=120,
             header_style="",
             box=SIMPLE,
         )
 
-        table.add_column("型定義", style="cyan", no_wrap=True, width=25)
-        table.add_column("ファイル", style="blue", no_wrap=True, width=20)
-        table.add_column("行", justify="right", style="green", width=5)
-        table.add_column("使用回数", justify="right", width=8)
-        table.add_column("推奨", no_wrap=False, width=60)
+        table.add_column("Type Definition", style="cyan", no_wrap=True, width=25)
+        table.add_column("File", style="blue", no_wrap=True, width=20)
+        table.add_column("Line", justify="right", style="green", width=5)
+        table.add_column("Usage Count", justify="right", width=8)
+        table.add_column("Recommendation", no_wrap=False, width=60)
 
         for detail in details[:30]:  # 最大30件まで表示
             # 型名を短く表示
@@ -958,18 +958,18 @@ class TypeReporter:
     def _create_unused_types_table(self, details: list[UnusedTypeDetail]) -> Table:
         """被参照0型の詳細テーブルを生成"""
         table = Table(
-            title="被参照0の型定義",
+            title="Unused Type Definitions",
             show_header=True,
             width=120,
             header_style="",
             box=SIMPLE,
         )
 
-        table.add_column("型定義", style="cyan", no_wrap=True, width=25)
-        table.add_column("ファイル", style="blue", no_wrap=True, width=20)
-        table.add_column("行", justify="right", style="green", width=5)
-        table.add_column("レベル", justify="center", width=8)
-        table.add_column("推奨", no_wrap=False, width=60)
+        table.add_column("Type Definition", style="cyan", no_wrap=True, width=25)
+        table.add_column("File", style="blue", no_wrap=True, width=20)
+        table.add_column("Line", justify="right", style="green", width=5)
+        table.add_column("Level", justify="center", width=8)
+        table.add_column("Recommendation", no_wrap=False, width=60)
 
         for detail in details[:30]:  # 最大30件まで表示
             # 型名を短く表示
@@ -1003,18 +1003,18 @@ class TypeReporter:
     ) -> Table:
         """非推奨typing使用の詳細テーブルを生成"""
         table = Table(
-            title="非推奨typing使用",
+            title="Deprecated typing Usage",
             show_header=True,
             width=120,
             header_style="",
             box=SIMPLE,
         )
 
-        table.add_column("ファイル", style="cyan", no_wrap=True, width=25)
-        table.add_column("行", justify="right", style="green", width=5)
-        table.add_column("非推奨型", justify="center", width=15)
-        table.add_column("推奨代替", justify="center", width=15)
-        table.add_column("コード", no_wrap=False, width=60)
+        table.add_column("File", style="cyan", no_wrap=True, width=25)
+        table.add_column("Line", justify="right", style="green", width=5)
+        table.add_column("Deprecated Type", justify="center", width=15)
+        table.add_column("Recommended Alternative", justify="center", width=15)
+        table.add_column("Code", no_wrap=False, width=60)
 
         for detail in details[:30]:  # 最大30件まで表示
             # ファイル名を短く表示

--- a/tests/test_issues_analyzer.py
+++ b/tests/test_issues_analyzer.py
@@ -125,9 +125,9 @@ class TestProjectAnalyzer:
         analyzer.print_summary(summary)
 
         captured = capsys.readouterr()
-        assert "✅ Successful checks: 2/3" in captured.out
-        assert "❌ Failed checks: 1/3" in captured.out
-        assert "💡 Recommendations:" in captured.out
+        assert "✅ 成功したチェック: 2/3" in captured.out
+        assert "❌ 失敗したチェック: 1/3" in captured.out
+        assert "💡 推奨事項:" in captured.out
 
     def test_save_report_json(self, tmp_path):
         """レポート保存のテスト"""

--- a/tests/test_issues_analyzer.py
+++ b/tests/test_issues_analyzer.py
@@ -125,9 +125,9 @@ class TestProjectAnalyzer:
         analyzer.print_summary(summary)
 
         captured = capsys.readouterr()
-        assert "✅ 成功したチェック: 2/3" in captured.out
-        assert "❌ 失敗したチェック: 1/3" in captured.out
-        assert "💡 推奨事項:" in captured.out
+        assert "✅ Successful checks: 2/3" in captured.out
+        assert "❌ Failed checks: 1/3" in captured.out
+        assert "💡 Recommendations:" in captured.out
 
     def test_save_report_json(self, tmp_path):
         """レポート保存のテスト"""

--- a/tests/test_project_analyze.py
+++ b/tests/test_project_analyze.py
@@ -127,8 +127,8 @@ max_depth = 5
                 result = runner.invoke(cli, ["project-analyze"])
 
                 assert result.exit_code == 0
-                assert "プロジェクト解析開始" in result.output
-                assert "プロジェクト解析が完了しました" in result.output
+                assert "🚀 Project Analysis" in result.output
+                assert "✅ Project analysis completed" in result.output
 
                 # 生成ファイルの確認
                 output_dir = temp_path / "generated_docs"
@@ -359,8 +359,8 @@ extract_deps = true
 
                 # 結果の検証
                 assert result.exit_code == 0
-                assert "プロジェクト解析開始" in result.output
-                assert "プロジェクト解析が完了しました" in result.output
+                assert "🚀 Project Analysis" in result.output
+                assert "✅ Project analysis completed" in result.output
 
                 # 生成ファイルの確認（出力ディレクトリが作成される）
                 docs_dir = temp_path / "docs"


### PR DESCRIPTION
## 🎯 背景と動機

Issue #36のUI設計指針に基づき、CLI出力の項目名を英語に統一することで、モダンなCLIツールとしてのプロフェッショナルな印象を確立し、国際的な開発者体験の向上を図る必要がありました。項目名は英語で統一しつつ、説明文は日本語を維持することで、可読性と国際化対応のバランスを取っています。

## 📋 ゴール設定

### 達成目標
- CLI出力のテーブルヘッダーと項目名を英語に統一
- 日本語の説明文とMarkdownドキュメントは維持
- モダンCLIツールとしての統一感の確立

## ✅ MUST要件（マージ必須）
- [x] type_reporter.pyのテーブルヘッダーを英語化（Level, Count, Ratio, Status等）
- [x] analyze_types.pyとproject_analyze.pyの出力項目を英語化
- [x] テストファイルの出力文字列検証を更新
- [x] セクションタイトル（説明文）は日本語を維持
- [x] Markdownドキュメントは日本語を維持

## ⭐ BETTER要件（あれば良い）
- [x] 長い文字列のテーブルレイアウト調整
- [x] コードフォーマットの最適化

## 🔧 実装詳細

### 変更内容
- **type_reporter.py**: 型定義分析レポートのテーブルヘッダーを英語化
  - テーブルタイトル：`Type Definition Level Statistics`
  - カラム名：`Level`, `Count`, `Ratio`, `Status`等
- **analyze_types.py**: CLIコマンドの出力項目を英語化
- **project_analyze.py**: プロジェクト解析結果のテーブル項目を英語化
  - サマリーテーブル：`Analysis Summary`
  - 項目名：`Files Processed`, `Types Extracted`, `Deps Found`, `Docs Generated`
- **テストファイル**: 英語化された出力文字列の検証を更新

### 技術的決定事項
- テーブルヘッダーのみ英語化し、説明的なテキストは日本語を維持
- 長い英語文字列に対応するためテーブル幅を調整（250px）
- カラム幅の最適化で視認性の向上を図る

## 🧪 テストと検証

### 実施したテスト
- プロジェクト解析の実行テスト（`make analyze`）
- 型定義分析の実行テスト
- ユニットテストの実行確認
- コードフォーマットとリンターのチェック

### 検証結果
- ✅ プロジェクト解析が正常に動作し、英語の項目名で出力されることの確認
- ✅ テーブルレイアウトが適切に調整され、長い文字列が収まることの確認
- ✅ すべてのテストケースが通過することの確認
- ✅ コードフォーマットとリンターの基準を満たすことの確認

## 📁 変更ファイル

### 主要な変更
- `src/core/analyzer/type_reporter.py`: 型定義分析レポートのテーブルヘッダー英語化
- `src/cli/commands/analyze_types.py`: CLIコマンド出力の項目名英語化
- `src/cli/commands/project_analyze.py`: プロジェクト解析結果テーブルの項目名英語化
- `tests/test_issues_analyzer.py`: テストケースの出力文字列検証更新

### 依存関係への影響
- なし（出力文字列の変更のみ）

## 🚀 デプロイメント

### 必要な作業
- なし（出力文字列の変更のみで動作に影響なし）

## 🔄 ロールバック計画

### 問題発生時の対応
- 英語化された文字列を日本語に戻すコミットを作成
- テーブル幅の調整を元に戻す

## 📊 影響範囲

- **ユーザー影響**: CLI出力の項目名が英語になるが、説明文は日本語のままなので使い勝手に大きな影響なし
- **開発者影響**: コード内の出力文字列変更のみで、機能的な変更なし
- **メンテナンス性**: 項目名が英語になることで国際的な開発者にとって理解しやすくなる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - UIテキストを日本語から英語へ全面変更（トグル、パネル見出し/タイトル、進行状況、エラー/成功メッセージ、表タイトル/列名、サマリー表、詳細ラベル）。出力（Markdown/JSON/YAML）の表記も英語で統一し、レイアウトを微調整。
- バグ修正
  - エラー表示後に処理を打ち切る挙動を追加し、不要な後続処理を防止。
- テスト
  - 英語表記への変更に合わせて期待値を更新（サマリーの成功/失敗/推奨ラベル）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->